### PR TITLE
Remove trailing slash

### DIFF
--- a/samples/python/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/python/02.echo-bot/deploymentTemplates/template-with-preexisting-rg.json
@@ -146,7 +146,7 @@
                     "cors": {
                         "allowedOrigins": [
                             "https://botservice.hosting.portal.azure.net",
-                            "https://hosting.onecloud.azure-test.net/"
+                            "https://hosting.onecloud.azure-test.net"
                         ]
                     }
                 }


### PR DESCRIPTION
The preexisting RG ARM template for echo-bot has 2 CORS URLs, one that has a trailing `/`.

The App Service would normally give a warning about this on the UI. 